### PR TITLE
Listing request: derps.co

### DIFF
--- a/vcards/derps.co.xml
+++ b/vcards/derps.co.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<vcard>
+    <fn>
+        <text>derps.co</text>
+    </fn>
+    <kind>
+        <text>application</text>
+    </kind>
+    <url>
+        <uri>http://www.derps.co/</uri>
+    </url>
+    <registration xmlns="urn:xmpp:vcard:registration:1">
+        <uri>xmpp:derps.co</uri>
+    </registration>
+    <bday>
+        <date>2015</date>
+    </bday>
+    <adr>
+        <country>US</country>
+    </adr>
+    <ca xmlns="urn:xmpp:vcard:ca:0">
+        <name>StartSSL</name>
+        <uri>http://www.startssl.com/</uri>
+    </ca>
+    <name xmlns="jabber:iq:version">ejabberd</name>
+    <impp>
+        <uri>xmpp:michael@johnson.computer</uri>
+    </impp>
+    <geo>
+        <uri>geo:34.1,-84.0</uri>
+    </geo>
+    <lang>
+        <parameters>
+            <pref>1</pref>
+        </parameters>
+        <language-tag>en</language-tag>
+    </lang>
+    <email>
+        <text>support@johnson.computer</text>
+    </email>
+</vcard>


### PR DESCRIPTION
I'd love to add my newly hosted domain, derps.co, to the list.

As I don't intend to setup MX for this domain, verification can be sent to the hostmaster address of the domain that's hosting it: `hostmaster [at] johnson [dot] computer`. The fact that this domain is hosted by johnson.computer can be verified via the SRV records:

```
dig +short SRV _xmpp-client._tcp.derps.co
5 5 5222 ceres.xmpp.johnson.computer.
10 5 5222 vesta.xmpp.johnson.computer.
```